### PR TITLE
[non-related] fix: wrong `editLink`

### DIFF
--- a/docs/.vitepress/locales/zh-cn.ts
+++ b/docs/.vitepress/locales/zh-cn.ts
@@ -22,7 +22,7 @@ export default defineConfig({
         nav: nav(),
         sidebar: sidebar(),
         editLink: {
-            pattern: 'https://github.com/mspcmanager/mspcm-docs/edit/main/docs/zh-cn/:path',
+            pattern: 'https://github.com/mspcmanager/mspcm-docs/edit/main/docs/:path',
             text: '在 GitHub 上编辑此页'
         },
         footer: {


### PR DESCRIPTION
修复由于 `:path` 中自带有 `/zh-cn/` 而导致的编辑链接不正确问题。